### PR TITLE
Generalize oscillator to support playing multiple frequencies simultaneously

### DIFF
--- a/Sineweaver.swiftpm/Resources/Presets/Bass_Synth Bass.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Bass_Synth Bass.json
@@ -26,7 +26,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0,
-          "frequency" : 130.8127826502993,
+          "frequencies" : [
+            130.8127826502993
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 2,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Bass_Wah-Wah Bass.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Bass_Wah-Wah Bass.json
@@ -45,7 +45,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0,
-          "frequency" : 110,
+          "frequencies" : [
+            110
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 1,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Brass_Brass.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Brass_Brass.json
@@ -26,7 +26,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.23032672119140626,
-          "frequency" : 261.6255653005986,
+          "frequencies" : [
+            261.6255653005986
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 3,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Drums_Kick.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Drums_Kick.json
@@ -35,7 +35,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0,
-          "frequency" : 65.40639132514966,
+          "frequencies" : [
+            65.40639132514966
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 1,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Electronic_Mixed Lead.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Electronic_Mixed Lead.json
@@ -93,7 +93,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.49727073669433597,
-          "frequency" : 440,
+          "frequencies" : [
+            440
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 3,
           "prefersPianoView" : false,
@@ -110,7 +112,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.07413249206542968,
-          "frequency" : 130.8127826502993,
+          "frequencies" : [
+            130.8127826502993
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 2,
           "prefersPianoView" : false,

--- a/Sineweaver.swiftpm/Resources/Presets/Electronic_Saw Lead.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Electronic_Saw Lead.json
@@ -50,7 +50,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.09766127014160156,
-          "frequency" : 523.2511306011972,
+          "frequencies" : [
+            523.2511306011972
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 4,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Folk_Pan Flute.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Folk_Pan Flute.json
@@ -26,7 +26,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.24674816894531254,
-          "frequency" : 261.6255653005986,
+          "frequencies" : [
+            261.6255653005986
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 3,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Resources/Presets/Strings_Strings.json
+++ b/Sineweaver.swiftpm/Resources/Presets/Strings_Strings.json
@@ -72,7 +72,9 @@
       "oscillator" : {
         "_0" : {
           "detune" : 0.04354193115234378,
-          "frequency" : 261.6255653005986,
+          "frequencies" : [
+            261.6255653005986
+          ],
           "isPlaying" : false,
           "pianoBaseOctave" : 3,
           "prefersPianoView" : true,

--- a/Sineweaver.swiftpm/Sources/Audio/Synthesizer/Synthesizer.swift
+++ b/Sineweaver.swiftpm/Sources/Audio/Synthesizer/Synthesizer.swift
@@ -177,15 +177,16 @@ final class Synthesizer: Sendable {
         switch midiMessage.type {
         case .channelVoice2:
             let v2Message = midiMessage.channelVoice2
+            // TODO: Add support for multiple notes
             switch v2Message.status {
             case .noteOn:
                 let note = Note(midiNumber: Int(v2Message.note.number))
                 Task { @MainActor in
-                    model.setPlaying(note: note)
+                    model.setPlaying(notes: [note])
                 }
             case .noteOff:
                 Task { @MainActor in
-                    model.setPlaying(note: nil)
+                    model.setPlaying(notes: [])
                 }
             default:
                 break

--- a/Sineweaver.swiftpm/Sources/Audio/Synthesizer/Synthesizer.swift
+++ b/Sineweaver.swiftpm/Sources/Audio/Synthesizer/Synthesizer.swift
@@ -49,6 +49,12 @@ final class Synthesizer: Sendable {
         }
     }
     
+    @MainActor private var activeMidiNotes: Set<Note> = [] {
+        didSet {
+            model.setPlaying(notes: activeMidiNotes.sorted())
+        }
+    }
+    
     let startTimestamp: SendableAtomic<TimeInterval> = .init(0)
     let level: SendableAtomic<Double> = .init(0)
     
@@ -177,16 +183,15 @@ final class Synthesizer: Sendable {
         switch midiMessage.type {
         case .channelVoice2:
             let v2Message = midiMessage.channelVoice2
-            // TODO: Add support for multiple notes
+            let note = { Note(midiNumber: Int(v2Message.note.number)) }
             switch v2Message.status {
             case .noteOn:
-                let note = Note(midiNumber: Int(v2Message.note.number))
                 Task { @MainActor in
-                    model.setPlaying(notes: [note])
+                    activeMidiNotes.insert(note())
                 }
             case .noteOff:
                 Task { @MainActor in
-                    model.setPlaying(notes: [])
+                    activeMidiNotes.remove(note())
                 }
             default:
                 break

--- a/Sineweaver.swiftpm/Sources/Model/Synthesizer/SynthesizerModel.swift
+++ b/Sineweaver.swiftpm/Sources/Model/Synthesizer/SynthesizerModel.swift
@@ -83,22 +83,20 @@ struct SynthesizerModel: Hashable, Codable, Sendable {
     }
     
     /// Updates the playing note on all input controllers/oscillators.
-    /// Used for MIDI input. Note that we currently do not support multiple notes.
-    mutating func setPlaying(note: Note?, tuning: any Tuning = EqualTemperament()) {
+    /// Used for MIDI input.
+    mutating func setPlaying(notes: [Note], tuning: any Tuning = EqualTemperament()) {
         // TODO: Add support for playing multiple notes, both for multi-touch and MIDI, see #18
         for (id, node) in nodes.filter({ inputEdges[$0.key]?.isEmpty ?? true }) {
             switch node {
             case .controller(var controller):
-                if let note {
+                if let note = notes.first {
                     controller.frequency = tuning.pitchHz(for: note)
                 }
-                controller.isActive = note != nil
+                controller.isActive = !notes.isEmpty
                 nodes[id] = .controller(controller)
             case .oscillator(var oscillator):
-                if let note {
-                    oscillator.frequency = tuning.pitchHz(for: note)
-                }
-                oscillator.isPlaying = note != nil
+                oscillator.frequencies = notes.map(tuning.pitchHz(for:))
+                oscillator.isPlaying = !notes.isEmpty
                 nodes[id] = .oscillator(oscillator)
             default:
                 break

--- a/Sineweaver.swiftpm/Sources/View/Synthesizer/SynthesizerChartView.swift
+++ b/Sineweaver.swiftpm/Sources/View/Synthesizer/SynthesizerChartView.swift
@@ -45,7 +45,7 @@ struct SynthesizerChartView<Node>: View where Node: SynthesizerNodeProtocol {
 #Preview {
     VStack(spacing: 50) {
         ForEach(OscillatorNode.Wave.allCases, id: \.self) { wave in
-            SynthesizerChartView(node: OscillatorNode(wave: wave, frequency: 40))
+            SynthesizerChartView(node: OscillatorNode(wave: wave, frequencies: [40]))
                 .frame(maxHeight: 100)
         }
     }

--- a/Sineweaver.swiftpm/Sources/View/Synthesizer/SynthesizerOscillatorView.swift
+++ b/Sineweaver.swiftpm/Sources/View/Synthesizer/SynthesizerOscillatorView.swift
@@ -139,7 +139,7 @@ struct SynthesizerOscillatorView: View {
 }
 
 #Preview {
-    @Previewable @State var nodes = OscillatorNode.Wave.allCases.map { OscillatorNode(wave: $0, frequency: 40) }
+    @Previewable @State var nodes = OscillatorNode.Wave.allCases.map { OscillatorNode(wave: $0, frequencies: [40]) }
     
     VStack(spacing: 50) {
         ForEach(Array(nodes.indices), id: \.self) { i in


### PR DESCRIPTION
### Fixes #18 

This adds support for multiple simultaneously playing notes in OscillatorNode, along with support for controlling these via MIDI. This makes it a lot more useful, especially in a DAW context where notes often overlap.

Note, however, that this is a breaking change and saved presets will have to be migrated manually (see the diff in this PR).